### PR TITLE
Makefile: Fix SDL2 linking issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CPPFLAGS = -Iinclude
 CFLAGS = $(shell pkg-config --cflags sdl2 SDL2_image)
-LDFLAGS = $(shell pkg-config --libs sdl2 SDL2_image)
+LIBS = $(shell pkg-config --libs sdl2 SDL2_image)
 CFLAGS += -Wall -O2
 BIN = sdl2test
 OBJS =				\
@@ -14,7 +14,7 @@ all: $(BIN)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
 
 $(BIN): $(OBJS)
-	$(CC) $(LDFLAGS) $^ -o $@
+	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)
 
 clean:
 	-rm -f $(OBJS)


### PR DESCRIPTION
Libraries linking flags should be always specified in the end of linking command. On some distributions (e.g. Ubuntu) fail to do so leads to the building error. Move libs linking to the end of linking command to fix that issue.

Signed-off-by: Yurii Protsenko <elsoul@gmail.com>